### PR TITLE
Color Count Update

### DIFF
--- a/bot/core/issues.py
+++ b/bot/core/issues.py
@@ -207,6 +207,22 @@ class ColorAmount(Issue):
         return f"{self.description.value}: {self.amount}"
 
 
+class TransparentAmount(Issue):
+    """
+    The number of transparent pixels in a sprite (excluding completely
+    transparent pixels).
+    """
+
+    description = Description.transparent_amount
+    severity = Severity.accepted
+
+    def __init__(self, amount: int) -> None:
+        self.amount = amount
+
+    def __str__(self) -> str:
+        return f"{self.description.value}: {self.amount}"
+
+
 class ColorExcessRefused(Issue):
     description = Description.colour_excess
     severity = Severity.refused

--- a/bot/core/sprite_analysis.py
+++ b/bot/core/sprite_analysis.py
@@ -66,31 +66,11 @@ class SpriteContext():
         self.pixels = get_pixels(self.image)
 
         self.color_count: int = 0
-        """ The number of unique RGB values in an image with an alpha value greater than 0. 
-        This count treats all semi-transparent pixels as though they had an alpha of 255.
-        """
         self.transparent_count: int = 0
-        """
-        The number of unique RGBA values in an image with an alpha value less than 255 and greater
-        than 0.
-        """
         self.actual_color_count: int = 0
-        """
-        The number of colors in a sprite, excluding fully transparent pixels.
-        If this value does not equal ``color_count + transparent_count``, that is
-        because one or more RGB value in an image never had an alpha value 
-        equal to 255.
-        
-        Replaces useful_amount.
-        """
-
         self.useless_amount: int = 0
-        """ The number of pixels in an image minus the number of useful colors. 
-        Used when determining Aseperite ratio.
-        """
 
         self.useful_colors: list = []
-        """ The color palette used. """
         self.similar_color_dict: dict = {}
 
         if analysis.fusion_filename.id_type.is_custom_base():

--- a/bot/misc/enums.py
+++ b/bot/misc/enums.py
@@ -3,6 +3,7 @@ from enum import Enum, auto
 import discord
 
 
+# NOTE: This should probably be a StrEnum instead.
 class Description(str, Enum):
     missing_file        = "Missing sprite"
     missing_filename    = "Missing filename"
@@ -14,6 +15,7 @@ class Description(str, Enum):
     intentional_transp  = "Intentional transparency"
     half_pixels         = "Half pixels detected"
     colour_amount       = "Colors"
+    transparent_amount  = "Transparent Colors",
     file_name           = "Filename"
     invalid_fusion_id   = "Invalid fusion ID"
     incorrect_gallery   = "Incorrect gallery"


### PR DESCRIPTION
The bot now counts transparent colors and opaque colors seperately so that identical RGB values with differing alpha values do not contribute to the total color count.